### PR TITLE
make initial directory scan much faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bin/
 scratch/
 /procswap
 *.coverprofile
+/test

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/billiford/go-ps v1.0.3
 	github.com/eiannone/keyboard v0.0.0-20200508000154-caf4b762e807
 	github.com/google/uuid v1.2.0
-	github.com/logrusorgru/aurora v2.0.3+incompatible
+	github.com/karrick/godirwalk v1.16.1 // indirect
+	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/mattn/go-colorable v0.1.8
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.3

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
+github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=

--- a/internal/app.go
+++ b/internal/app.go
@@ -2,11 +2,11 @@ package procswap
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/karrick/godirwalk"
 	"github.com/logrusorgru/aurora"
 	"github.com/urfave/cli/v2"
 )
@@ -135,8 +135,7 @@ func run(c *cli.Context) error {
 		logInfo(fmt.Sprintf("%s registered priority script %s", aurora.Cyan("setup"), aurora.Bold(ps)))
 	}
 	// Set limit for loop to run.
-	limit := c.Int(flagLimitName)
-	if limit > 0 {
+	if limit := c.Int(flagLimitName); limit > 0 {
 		loop.WithLimit(limit)
 	}
 	// Set the poll interval.
@@ -154,9 +153,9 @@ func run(c *cli.Context) error {
 	return nil
 }
 
-func listExecutables(paths, ignored []string) []os.FileInfo {
+func listExecutables(paths, ignored []string) []*godirwalk.Dirent {
 	// These are our "priority executables".
-	pe := []os.FileInfo{}
+	pe := []*godirwalk.Dirent{}
 
 	// Priority and swap process setup.
 	for _, pd := range paths {
@@ -173,10 +172,9 @@ func listExecutables(paths, ignored []string) []os.FileInfo {
 	return pe
 }
 
-func swaps(pe []os.FileInfo, sp []string) []Swap {
+func swaps(pe []*godirwalk.Dirent, sp []string) []Swap {
 	// Make sure there's no intersection here, that would be a nightmare.
-	err := intersect(pe, sp)
-	if err != nil {
+	if err := intersect(pe, sp); err != nil {
 		logFatal(err.Error())
 	}
 
@@ -188,7 +186,7 @@ func swaps(pe []os.FileInfo, sp []string) []Swap {
 	return swaps
 }
 
-func intersect(files []os.FileInfo, swaps []string) error {
+func intersect(files []*godirwalk.Dirent, swaps []string) error {
 	filesMap := map[string]bool{}
 
 	for _, file := range files {

--- a/internal/path_test.go
+++ b/internal/path_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/google/uuid"
+	"github.com/karrick/godirwalk"
 
 	. "github.com/billiford/procswap/internal"
 	. "github.com/onsi/ginkgo"
@@ -13,7 +14,7 @@ import (
 
 var _ = Describe("Path", func() {
 	var (
-		infos   []os.FileInfo
+		infos   []*godirwalk.Dirent
 		ignored []string
 		path    string
 		err     error


### PR DESCRIPTION
Using `godirwalk.Walk` instead of `filepath.Wallk` I was able to get the initial directory scan down from ~4 minutes to ~15 seconds for a directory with 300,000+ files.

Read more about `godirwalk` [here](https://github.com/karrick/godirwalk).